### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Actions for android animations. Inspired by libgdx scene2d actions.
 The main goal of this project is making creating of complex animations easier.
 You may create animations like in demo with just a couple lines of code.
 
-##Actions
+## Actions
 `sequence` - executes actions sequentially <br/>
 `delay` - inserts pause into sequence <br/>
 `run` - will run target runnable, useful in sequences <br/>
@@ -26,7 +26,7 @@ You may create animations like in demo with just a couple lines of code.
 
 `play` - plays specified action on specified view<br/>
 
-##Interpolations
+## Interpolations
 Library contains class `Interpolations` with different predefined interpolations which may be useful for animations.
 
 ## Demo


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
